### PR TITLE
Add RawValue property to BarcodeResult

### DIFF
--- a/GoogleVisionBarCodeScanner/Android/CameraPreview.cs
+++ b/GoogleVisionBarCodeScanner/Android/CameraPreview.cs
@@ -180,10 +180,12 @@ namespace GoogleVisionBarCodeScanner
                             if (barcode == null) continue;
                             var type = Methods.ConvertBarcodeResultTypes(barcode.ValueFormat);
                             var value = barcode.DisplayValue;
+                            var rawValue = barcode.RawValue;
                             barcodeResults.Add(new BarcodeResult
                             {
                                 BarcodeType = type,
-                                DisplayValue = value
+                                DisplayValue = value,
+                                RawValue = rawValue
                             });
                         }
                         OnDetected?.Invoke(barcodeResults);

--- a/GoogleVisionBarCodeScanner/Android/Methods.cs
+++ b/GoogleVisionBarCodeScanner/Android/Methods.cs
@@ -184,10 +184,12 @@ namespace GoogleVisionBarCodeScanner
                 Barcode barcode = qrcodes.ValueAt(i) as Barcode;
                 var type = Methods.ConvertBarcodeResultTypes(barcode.ValueFormat);
                 var value = barcode.DisplayValue;
+                var rawValue = barcode.RawValue;
                 barcodeResults.Add(new BarcodeResult
                 {
                     BarcodeType = type,
-                    DisplayValue = value
+                    DisplayValue = value,
+                    RawValue = rawValue
                 });
             }
             return barcodeResults;

--- a/GoogleVisionBarCodeScanner/Shared/BarcodeResult.cs
+++ b/GoogleVisionBarCodeScanner/Shared/BarcodeResult.cs
@@ -8,5 +8,6 @@ namespace GoogleVisionBarCodeScanner
     {
         public BarcodeTypes BarcodeType { get; set; }
         public string DisplayValue { get; set; }
+        public string RawValue { get; set; }
     }
 }

--- a/GoogleVisionBarCodeScanner/iOS/Methods.cs
+++ b/GoogleVisionBarCodeScanner/iOS/Methods.cs
@@ -170,7 +170,8 @@ namespace GoogleVisionBarCodeScanner
                 resultList.Add(new BarcodeResult
                 {
                     BarcodeType = Methods.ConvertBarcodeResultTypes(barcode.ValueType),
-                    DisplayValue = barcode.DisplayValue
+                    DisplayValue = barcode.DisplayValue,
+                    RawValue = barcode.RawValue
                 });
             }
             return resultList;

--- a/GoogleVisionBarCodeScanner/iOS/UICameraPreview.cs
+++ b/GoogleVisionBarCodeScanner/iOS/UICameraPreview.cs
@@ -330,7 +330,8 @@ namespace GoogleVisionBarCodeScanner
                             resultList.Add(new BarcodeResult
                             {
                                 BarcodeType = Methods.ConvertBarcodeResultTypes(barcode.ValueType),
-                                DisplayValue = barcode.DisplayValue
+                                DisplayValue = barcode.DisplayValue,
+                                RawValue= barcode.RawValue
                             });
                         }
                         OnDetected?.Invoke(resultList);


### PR DESCRIPTION
Hello,

When BacodeType is unknown, DisplayValue is truncated.
RawValue is mandatory to decode custom QrCode types (for example air tickets) and get all the data.