### PR TITLE
Update Main.cs

### DIFF
--- a/SampleApp/SampleApp.iOS/Main.cs
+++ b/SampleApp/SampleApp.iOS/Main.cs
@@ -14,7 +14,7 @@ namespace SampleApp.iOS
         {
             // if you want to use a different Application Delegate class from "AppDelegate"
             // you can specify it here.
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, null, typeof(AppDelegate));
         }
     }
 }


### PR DESCRIPTION
To avoid the CS0618 Warning for calling the Main method with a string parameter (is obsolete).