### PR TITLE
Improve Analyze on Android

### DIFF
--- a/GoogleVisionBarCodeScanner/Android/Renderer/CameraViewRenderer.cs
+++ b/GoogleVisionBarCodeScanner/Android/Renderer/CameraViewRenderer.cs
@@ -269,12 +269,12 @@ namespace GoogleVisionBarCodeScanner.Renderer
 
             public async void Analyze(IImageProxy proxy)
             {
-
-                var mediaImage = proxy.Image;
-                if (mediaImage == null) return;
-                _lastRunTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
                 try
                 {
+                    var mediaImage = proxy.Image;
+                    if (mediaImage == null) return;
+                    _lastRunTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+                    
                     if (_lastRunTime - _lastAnalysisTime > _renderer.Element.ScanInterval && _renderer.Element.IsScanning)
                     {
                         _lastAnalysisTime = _lastRunTime;


### PR DESCRIPTION
This PR improves error handling on Android. In certain cases I observed following crash:

System.NullReferenceException: Object reference not set to an instance of an object
CameraViewRenderer+BarcodeAnalyzer.Analyze (AndroidX.Camera.Core.IImageProxy proxy)
AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_1 (System.Object state)
QueueUserWorkItemCallback.WaitCallback_Context (System.Object state)
ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx)
ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx)
IThreadPoolWorkItem.ExecuteWorkItem ()
ThreadPoolWorkQueue.Dispatch ()
_ThreadPoolWaitCallback.PerformWaitCallback ()

This can occur if the proxy is null, so I moved everything to the try-catch block.