### PR TITLE
Android context wrapper bug fix

### DIFF
--- a/GoogleVisionBarCodeScanner/Android/Renderer/CameraViewRenderer.cs
+++ b/GoogleVisionBarCodeScanner/Android/Renderer/CameraViewRenderer.cs
@@ -110,13 +110,15 @@ namespace GoogleVisionBarCodeScanner.Renderer
 
             try
             {
+                // Unbind use cases before rebinding
+                cameraProvider.UnbindAll();
+
+                // Searching for lifecycle owner
+                // There can be context wrapper instead of context it self, so we have to check it.
                 var lifecycleOwner = Context as ILifecycleOwner ?? (Context as ContextWrapper)?.BaseContext as ILifecycleOwner;
 
                 if (lifecycleOwner == null)
                     throw new Exception("Unable to find lifecycle owner");
-
-                // Unbind use cases before rebinding
-                cameraProvider.UnbindAll();
                 
                 // Bind use cases to camera
                 _camera = cameraProvider.BindToLifecycle(lifecycleOwner, cameraSelector, preview, imageAnalyzer);

--- a/GoogleVisionBarCodeScanner/Android/Renderer/CameraViewRenderer.cs
+++ b/GoogleVisionBarCodeScanner/Android/Renderer/CameraViewRenderer.cs
@@ -110,12 +110,16 @@ namespace GoogleVisionBarCodeScanner.Renderer
 
             try
             {
+                var lifecycleOwner = Context as ILifecycleOwner ?? (Context as ContextWrapper)?.BaseContext as ILifecycleOwner;
+
+                if (lifecycleOwner == null)
+                    throw new Exception("Unable to find lifecycle owner");
+
                 // Unbind use cases before rebinding
                 cameraProvider.UnbindAll();
-                if (Context == null)
-                    return;
+                
                 // Bind use cases to camera
-                _camera = cameraProvider.BindToLifecycle((ILifecycleOwner)Context, cameraSelector, preview, imageAnalyzer);
+                _camera = cameraProvider.BindToLifecycle(lifecycleOwner, cameraSelector, preview, imageAnalyzer);
 
                 HandleCustomPreviewSize(preview);
                 HandleTorch();


### PR DESCRIPTION
App crashes in some cases on Android platform.

I've found out that view's `Context` can be `MainActivity` which implements `ILifecycleOwner` - it's ok, or can be `ContextWrapper` that does not implements `ILifecycleOwner` and causes the exception and app crash.

```
Specified cast is not valid.
  at GoogleVisionBarCodeScanner.Renderer.CameraViewRenderer.CameraCallback () [0x0012e] in <7d896506c72f40389c6f5c6bb7398d6f>:0 
  at Java.Lang.Runnable.Run () [0x00000] in /Users/builder/azdo/_work/1/s/xamarin-android/src/Mono.Android/Java.Lang/Runnable.cs:27 
  at Java.Lang.IRunnableInvoker.n_Run (System.IntPtr jnienv, System.IntPtr native__this) [0x00008] in /Users/builder/azdo/_work/1/s/xamarin-android/src/Mono.Android/obj/Release/monoandroid10/android-30/mcw/Java.Lang.IRunnable.cs:84 
  at (wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.86(intptr,intptr)
```

This PR fixes the described bug.